### PR TITLE
Correct example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ try DeliciousRecipes().publish(
         )),
         // Add default titles to all sections
         .step(named: "Default section titles") { context in
-            guard section.title.isEmpty else { return }
-        
             context.mutateAllSections { section in
+                guard section.title.isEmpty else { return }
+                
                 switch section.id {
                 case .recipes:
                     section.title = "My recipes"


### PR DESCRIPTION
* **Fixed**: The example code for `.step(named: "Default section titles")` did not work due to a minor code order issue.
* **Pending**:  In one of the following code blocks, this publishing pipeline is presented:
    ```
    try DeliciousRecipes().publish(using: [
    .addMarkdownFiles(),
    .copyResources(),
    .addFavoriteItems(),
    .addDefaultSectionTitles(),
    .generateHTML(withTheme: .delicious),
    .generateRSSFeed(including: [.recipes]),
    .generateSiteMap()
    ])
    ```
    The step `.addFavoriteItems()`has not been introduced before nor is it introduced later on. Is it planned to add an example for this publishing step, should I draft an example, or can this publishing step be removed?